### PR TITLE
Follow `nightly` instead of `stable`

### DIFF
--- a/HumanEvalLean/HumanEval51.lean
+++ b/HumanEvalLean/HumanEval51.lean
@@ -1,5 +1,3 @@
-import Std.Data.Iterators.Combinators.FilterMap
-
 def IsSubseq (s₁ : String) (s₂ : String) : Prop :=
   List.Sublist s₁.toList s₂.toList
 

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.21.0
+leanprover/lean4:nightly-2025-08-18


### PR DESCRIPTION
`human-eval-lean` will become a canary project to detect breaking changes to Lean, so we will be tracking `nightly` instead of `stable` from now on.